### PR TITLE
docs: add HOW_IT_WORKS with Base 8453 details

### DIFF
--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -1,0 +1,10 @@
+# How it works
+- WalletConnect Modal v2 + Universal Provider via ESM CDN.
+- Targets **Base mainnet** only: `eip155:8453` (hex `0x2105`).
+- Shows account after connect and runs a `personal_sign` test.
+- No framework/bundler; pure single-file HTML/JS.
+- Screenshots: see [/proof](./proof).
+
+## Run
+- Open `index.html` directly, or visit:
+  https://wanbogang.github.io/wc-base8453-minidemo/


### PR DESCRIPTION
This PR adds HOW_IT_WORKS.md with details on how the mini demo works:

- Uses WalletConnect Modal v2 + Universal Provider via ESM CDN
- Targets Base mainnet only: eip155:8453 (hex 0x2105)
- Displays connected account and runs a personal_sign test
- Pure single-file HTML/JS (no framework/bundler)
- Screenshots for proof are available under /proof

Live demo: https://wanbogang.github.io/wc-base8453-minidemo/
Repository: https://github.com/Wanbogang/wc-base8453-minidemo
